### PR TITLE
Pass mExogenousData to hierarchical models

### DIFF
--- a/TS/SignalHierarchy.py
+++ b/TS/SignalHierarchy.py
@@ -168,7 +168,7 @@ class cSignalHierarchy:
                 logger.info("TRAINING_MODEL_LEVEL_SIGNAL " + str(level) + " " + str(signal));
                 lEngine = autof.cForecastEngine()
                 lEngine.mOptions = self.mOptions;
-                lEngine.train(iAllLevelsDataset , iDateColumn , signal, H);
+                lEngine.train(iAllLevelsDataset , iDateColumn , signal, H, iExogenousData=self.mExogenousData);
                 lEngine.getModelInfo();
                 self.mModels[level][signal] = lEngine;
         # print("CREATED_MODELS", self.mLevels, self.mModels)


### PR DESCRIPTION
Within SignalHierarchy.create_all_levels_models, the call to cForecastEngine.train method does not pass mExogenousData.

Since cForecastEngine.train accepts iExogenousData as an optional argument, this commit passes self.mExogenousData.  

